### PR TITLE
Make a elements on navbar expand to fill parent

### DIFF
--- a/styles/_nav.scss
+++ b/styles/_nav.scss
@@ -70,13 +70,8 @@ nav.nav {
 
             li {
               list-style-type: none;
-              display: flex;
-              flex-wrap: wrap;
-              align-items: center;
               width: 100%;
               height: 100%;
-              transition: all ease 0.3s;
-              cursor: pointer;
               background-color: inherit;
 
               a {
@@ -84,19 +79,22 @@ nav.nav {
                 color: inherit;
                 padding-left: 1rem;
                 padding-right: 1rem;
+                display: block;
+                width: 100%;
+                height: 100%;
+                line-height: $nav-height;
+                background-color: inherit;
+                cursor: pointer;
+                transition: all ease 0.3s;
               }
 
               a.active {
                 color: $link-text-active;
               }
-            }
 
-            li:hover {
-              color: $white;
-              background-color: $theme;
-
-              a {
-                color: inherit;
+              a:hover {
+                color: $white;
+                background-color: $theme;
               }
             }
           }


### PR DESCRIPTION
# Summary
This is a pull request for #2. This remove flex feature from li elements on the navigation bar, and set the width, height of a elements to 100%, and add line height value to it so the a elements expand and fit the size of parent li elements.

# How Did You Test This Change
1. Publish the built code to `gh-pages` branch
2. Open the web page on iPhone 12 Pro
3. Click the toggle button on the navigation bar
4. Assert that the menu items appeared
5. Click on the blank area of first menu item with index finger
6. Assert that the background color of the menu item was changed to black, and the text color was changed to white