### PR TITLE
Add dropdown feature to navigation bar

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,10 +20,23 @@
             </div>
             <div class="nav-content">
               <ul>
-                <li><a class="active" href="#">HOME</a></li>
-                <li><a href="#">ABOUT</a></li>
-                <li><a href="#">SERVICES</a></li>
-                <li><a href="#">CONTACT US</a></li>
+                <li><a class="active" href="#">Home</a></li>
+                <li><a href="#">About</a></li>
+                <li class="dropdown">
+                  <a class="dropdown-toggle">Services</a>
+                  <ul class="dropdown-menu">
+                    <li><a href="#">Basic Solution</a></li>
+                    <li><a href="#">Advanced Solution</a></li>
+                    <li><a href="#">Extreme Solution</a></li>
+                    <li><a href="#">Tailored Solution</a></li>
+                    <li><a href="#">Classic Solution</a></li>
+                    <li><a href="#">Green Solution</a></li>
+                    <li><a href="#">Economical Solution</a></li>
+                    <li><a href="#">VIP Solution</a></li>
+                    <li><a href="#">Distinguished Solution</a></li>
+                  </ul>
+                </li>
+                <li><a href="#">Contact us</a></li>
               </ul>
             </div>
             <button class="nav-toggler" type="button">

--- a/scripts/navbar.ts
+++ b/scripts/navbar.ts
@@ -1,21 +1,58 @@
 const navbar = {
   init: function (navbar: Element): void {
-    const navToggler = navbar.querySelector(".nav-toggler");
-    navToggler?.addEventListener("click", () => {
-      const isToggled = navbar.classList.contains("toggled");
-      if (isToggled) {
-        navbar.classList.remove("toggled");
-      } else {
-        navbar.classList.add("toggled");
-      }
-    });
-    const navCover = document.createElement("div");
-    navCover.classList.add("nav-cover");
-    navCover.addEventListener("click", () => {
-      navbar.classList.remove("toggled");
-    });
-    navbar.appendChild(navCover);
+    initToggleFeature(navbar);
+    initDropdowns(navbar);
   },
 };
+
+function initToggleFeature(navbar: Element) {
+  const navToggler = navbar.querySelector(".nav-toggler");
+  navToggler?.addEventListener("click", () => {
+    toggleElem(navbar);
+  });
+  const navCover = document.createElement("div");
+  navCover.classList.add("nav-cover");
+  navCover.addEventListener("click", () => {
+    navbar.classList.remove("toggled");
+  });
+  navbar.appendChild(navCover);
+}
+
+function initDropdowns(navbar: Element) {
+  const dropdownItems: NodeListOf<Element> =
+    navbar.querySelectorAll("li.dropdown");
+  for (const dropdownItem of dropdownItems) {
+    dropdownItem.addEventListener("click", function (e) {
+      toggleElem(dropdownItem);
+      const menu: HTMLElement = dropdownItem.querySelector(
+        ".dropdown-menu"
+      ) as HTMLElement;
+      const elemBounds: DOMRect = menu.getBoundingClientRect();
+      const elemBottom: number = elemBounds.bottom;
+      const windowBottom: number = window.innerHeight;
+      if (elemBottom > windowBottom) {
+        menu.style.height =
+          (elemBounds.height - (elemBottom - windowBottom)).toString() + "px";
+      } else {
+        menu.style.height = "auto";
+      }
+      e.stopPropagation();
+      function handleClickOutsideDropdown() {
+        toggleElem(dropdownItem);
+        window.removeEventListener("click", handleClickOutsideDropdown);
+      }
+      window.addEventListener("click", handleClickOutsideDropdown);
+    });
+  }
+}
+
+function toggleElem(elem: Element) {
+  const isToggled = elem.classList.contains("toggled");
+  if (isToggled) {
+    elem.classList.remove("toggled");
+  } else {
+    elem.classList.add("toggled");
+  }
+}
 
 export { navbar };

--- a/styles/_nav.scss
+++ b/styles/_nav.scss
@@ -7,6 +7,7 @@ nav.nav {
   width: 100%;
   height: $nav-height;
   background-color: $white;
+  text-transform: uppercase;
   z-index: 999;
 
   .nav-wrapper {
@@ -69,6 +70,7 @@ nav.nav {
             background-color: inherit;
 
             li {
+              position: relative;
               list-style-type: none;
               width: 100%;
               height: 100%;
@@ -95,6 +97,49 @@ nav.nav {
               a:hover {
                 color: $white;
                 background-color: $theme;
+              }
+            }
+
+            li.dropdown {
+              a.dropdown-toggle::after {
+                content: "";
+                display: inline-block;
+                border-top: 0.3rem solid;
+                border-right: 0.3rem solid transparent;
+                border-bottom: 0;
+                border-left: 0.3rem solid transparent;
+                vertical-align: 0.255rem;
+                margin-left: 0.6rem;
+                transition: all ease 0.3s;
+              }
+
+              .dropdown-menu {
+                position: absolute;
+                display: none;
+                top: 100%;
+                overflow: scroll;
+                height: auto;
+                z-index: 999;
+                width: 100%;
+
+                li {
+                  height: $nav-height;
+                }
+              }
+            }
+
+            li.dropdown.toggled {
+              a.dropdown-toggle {
+                color: $white;
+                background-color: $theme;
+              }
+
+              a.dropdown-toggle::after {
+                transform: rotate(180deg);
+              }
+
+              .dropdown-menu {
+                display: block;
               }
             }
           }
@@ -162,6 +207,12 @@ nav.nav {
 
               li {
                 width: initial;
+              }
+
+              li.dropdown {
+                .dropdown-menu {
+                  width: max-content;
+                }
               }
             }
           }


### PR DESCRIPTION
# Summary
This is a pull request for #4. This adds `.dropdown*` CSS rules to `_nav.scss` and dropdown initialization scripts (please see function `initDropdowns(navbar: Element)`) to `navbar.ts` for adding dropdown menu items to navigation bar. This also adds a dropdown menu item which demonstrates the dropdown feature to navigation bar.

# How Did You Test This Change
1. Lunch the web page with Visual Studio Code
2. Open the web page with Chrome
3. Click the dropdown menu item
4. Assert the menu is opened
5. Click anywhere
6. Assert the menu is closed
7. Open Developer Console
8. Change Dimensions to iPhone 12 Pro
9. Click the toggle button on navigation bar
10. Click the dropdown menu item
11. Assert the menu is opened and a vertical scrollbar is shown for scrolling to hidden dropdown item
12. Click anywhere
13. Assert dropdown is closed